### PR TITLE
商品詳細表示機能

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :set_items, only: [:show]
   before_action :move_to_index, except: [:index, :show]
 
   def index
@@ -7,6 +8,9 @@ class ItemsController < ApplicationController
 
   def new
     @item = Item.new
+  end
+
+  def show
   end
 
   def create
@@ -23,6 +27,10 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:item_name, :price, :detail, :category_id, :condition_id, :burden_id, :prefecture_id,
                                  :delivery_date_id, :image).merge(user_id: current_user.id)
+  end
+
+  def set_items
+    @item = Item.find(params[:id])
   end
 
   def move_to_index

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -130,7 +130,7 @@
 
          <% @items.each do |item| %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id) do %>
         <div class='item-img-content'>
           <%= image_tag(item.image, class: "item-img") %>
 

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -7,7 +7,7 @@
       <%= "商品名" %>
     </h2>
     <div class="item-img-content">
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image ,class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class="sold-out">
         <span>Sold Out!!</span>
@@ -19,52 +19,54 @@
         ¥ 999,999,999
       </span>
       <span class="item-postage">
-        <%= "配送料負担" %>
+        <%= @item.burden.name %>
       </span>
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
     <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
+    <% end %>
 
-
+    <% if user_signed_in? && current_user.id != @item.user_id %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to "購入画面に進む", "#" ,class:"item-red-btn"%>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
+    <% end %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+      <span><%= @item.detail %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.last_name %> <%= @item.user.first_name %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.condition.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.burden.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.prefecture.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.delivery_date.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -23,7 +23,6 @@
       </span>
     </div>
 
-    <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
     <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
@@ -36,8 +35,6 @@
     <%# //商品が売れていない場合はこちらを表示しましょう %>
     <% end %>
 
-
-    <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
       <span><%= @item.detail %></span>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -4,7 +4,7 @@
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.item_name %>
     </h2>
     <div class="item-img-content">
       <%= image_tag @item.image ,class:"item-box-img" %>
@@ -105,9 +105,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <%# 詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
-  <a href="#" class="another-item"><%= "商品のカテゴリー名" %>をもっと見る</a>
-  <%# //詳細ページで表示されている商品のカテゴリー名を表示しましょう %>
+  <a href="#" class="another-item"><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -16,7 +16,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>円
       </span>
       <span class="item-postage">
         <%= @item.burden.name %>


### PR DESCRIPTION
＃What
商品の詳細情報を表示できるようにする。

＃Why
購入者が情報を詳細に確認できるようにするため。

Gyazo
（商品の値段が変わっていないことに途中で気がつきました。
　最後の動画では修正しています。）

ログイン状態且つ、自身が出品した販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/f8bae04f591f6a9975bcd1701933dd17

 ログイン状態且つ、自身が出品していない販売中商品の商品詳細ページへ遷移した動画
https://gyazo.com/e134b38e0474a92943fa030f7e3d2fcf

 ログイン状態で、売却済み商品の商品詳細ページへ遷移した動画（現段階で商品購入機能の実装が済んでいる場合）
＊まだです

 ログアウト状態で、商品詳細ページへ遷移した動画
https://gyazo.com/307443954d372637fc2eaacbab8a18fe